### PR TITLE
chore: bump techdocs image

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/techdocs:latest@sha256:ef5ef54af04ba6785fc6f367e3ef9a700db306642aaa0f542d98de2741344f88 as techdocs
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/techdocs:latest@sha256:d2b55ac2a670eadb4072a7f5f3e2c623737a318f53db799777d6243f052c1602 as techdocs


### PR DESCRIPTION
Dependabot wanted to update this image, but the repo+branch name became so long that the CI broke.

Dependabot PR: https://github.com/coopnorge/github-workflow-devtools-build-oci/pull/16
Dependabot branchname `dependabot/docker/docker-compose/coopnorge/engineering-docker-images/e0/techdocs-d2b55ac`
