### PR TITLE
feat: tag release with vX (major)

### DIFF
--- a/.github/workflows/release-tagger.yaml
+++ b/.github/workflows/release-tagger.yaml
@@ -1,0 +1,32 @@
+name: Release Tagger
+on:
+  release:
+    types:
+      - released
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Git
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+      - name: Remove old tag and tag main with vX
+        run: |
+          git fetch --all
+          git checkout main
+          # Extract vX from vX.Y.Z
+          NEW_TAG=$(echo "${{ github.event.release.tag_name }}" | cut -d'.' -f1)
+          # Check if tag already exists and delete if it does
+          if git show-ref --tags $NEW_TAG; then
+              git tag -d $NEW_TAG
+              git push --delete origin $NEW_TAG
+          fi
+          # Create new tag
+          git tag $NEW_TAG
+          git push origin refs/tags/$NEW_TAG


### PR DESCRIPTION
Github Actions/Workflow are usually tagged with v(major) alongside
the primary version v(major).(minor).(patch)

v(major) always follows the latest v(major).(minor).(patch)
version.

We have this in other workflows, but was missing here.
