### PR TITLE
fix: override OCI_TAG_SUFFIX_USER instead of oci_tag_suffixes_git

### DIFF
--- a/.github/workflows/oci-ci.yaml
+++ b/.github/workflows/oci-ci.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Validate
         run: docker compose run --rm ${{ inputs.docker-compose-service }} validate VERBOSE=all ENVIRONMENT=${{ inputs.environment }}
       - name: Build
-        run: docker compose run --rm ${{ inputs.docker-compose-service }} build VERBOSE=all ENVIRONMENT=${{ inputs.environment }} oci_tag_suffixes_git="${{ inputs.tags }}"
+        run: docker compose run --rm ${{ inputs.docker-compose-service }} build VERBOSE=all ENVIRONMENT=${{ inputs.environment }} OCI_TAG_SUFFIX_USER="${{ inputs.tags }}"
       - name: Autenticate with GCP
         if: ${{ inputs.publish }}
         uses: "google-github-actions/auth@v2.1.8"
@@ -97,7 +97,7 @@ jobs:
         run: gcloud auth print-access-token | docker login https://${{ inputs.artifact_registry_location }}-docker.pkg.dev -u oauth2accesstoken --password-stdin
       - name: Publish with Tag
         if: ${{ inputs.publish && inputs.tags != ''}}
-        run: docker compose run --rm ${{ inputs.docker-compose-service }} publish VERBOSE=all ENVIRONMENT=${{ inputs.environment }} oci_tag_suffixes_git="${{ inputs.tags }}"
+        run: docker compose run --rm ${{ inputs.docker-compose-service }} publish VERBOSE=all ENVIRONMENT=${{ inputs.environment }} OCI_TAG_SUFFIX_USER="${{ inputs.tags }}"
       - name: Publish
         if: ${{ inputs.publish }}
         run: docker compose run --rm ${{ inputs.docker-compose-service }} publish VERBOSE=all ENVIRONMENT=${{ inputs.environment }}


### PR DESCRIPTION
When overriding the `oci_tag_suffixes_git` it not use the makefile
generated `gitc-` tag. We should override `OCI_TAG_SUFFIX_USER ` because
then the `gitc-` tags will be appended.
